### PR TITLE
Remove bip0030

### DIFF
--- a/blockchain/doc.go
+++ b/blockchain/doc.go
@@ -75,7 +75,6 @@ Bitcoin Improvement Proposals
 This package includes spec changes outlined by the following BIPs:
 
 		BIP0016 (https://en.bitcoin.it/wiki/BIP_0016)
-		BIP0030 (https://en.bitcoin.it/wiki/BIP_0030)
 		BIP0034 (https://en.bitcoin.it/wiki/BIP_0034)
 */
 package blockchain

--- a/blockchain/fullblocktests/generate.go
+++ b/blockchain/fullblocktests/generate.go
@@ -1700,29 +1700,12 @@ func Generate(includeLargeReorg bool) (tests [][]TestInstance, err error) {
 	})
 	rejected(blockchain.ErrSpendTooHigh)
 
-	// ---------------------------------------------------------------------
-	// BIP0030 tests.
-	// ---------------------------------------------------------------------
-
 	// Create a good block to reset the chain to a stable base.
 	//
 	//   ... -> b57(16) -> b60(17)
 	g.setTip("b57")
 	g.nextBlock("b60", outs[17])
 	accepted()
-
-	// Create block that has a tx with the same hash as an existing tx that
-	// has not been fully spent.
-	//
-	//   ... -> b60(17)
-	//                 \-> b61(18)
-	g.nextBlock("b61", outs[18], func(b *wire.MsgBlock) {
-		// Duplicate the coinbase of the parent block to force the
-		// condition.
-		parent := g.blocks[b.Header.PrevBlock]
-		b.Transactions[0] = parent.Transactions[0]
-	})
-	rejected(blockchain.ErrOverwriteTx)
 
 	// ---------------------------------------------------------------------
 	// Blocks with non-final transaction tests.


### PR DESCRIPTION
Removes BIP0030, as we will activate BIP0034 from start, BIP0030 is no longer needed.