### PR TITLE
Updata json rpc methods

### DIFF
--- a/btcjson/chainsvrcmds.go
+++ b/btcjson/chainsvrcmds.go
@@ -48,6 +48,16 @@ func NewAddNodeCmd(addr string, subCmd AddNodeSubCmd) *AddNodeCmd {
 	}
 }
 
+// PosDataInput represents all data necessery to create correct commitment to data
+type PosDataInput struct {
+	Tag             string `json:"tag"`
+	HashOrData      string `json:"hashOrData"`
+	ProtectionLevel uint8  `json:"protectionLevel"`
+	// TODO-Babylon define if nonce is really needed and how it will be used
+	Nonce  uint32 `json:"nonce"`
+	PosSig string `json:"posSignature"`
+}
+
 // TransactionInput represents the inputs to a transaction.  Specifically a
 // transaction hash and output number pair.
 type TransactionInput struct {
@@ -60,6 +70,7 @@ type CreateRawTransactionCmd struct {
 	Inputs   []TransactionInput
 	Amounts  map[string]float64 `jsonrpcusage:"{\"address\":amount,...}"` // In BTC
 	LockTime *int64
+	PosData  *PosDataInput
 }
 
 // NewCreateRawTransactionCmd returns a new instance which can be used to issue
@@ -68,7 +79,7 @@ type CreateRawTransactionCmd struct {
 // Amounts are in BTC. Passing in nil and the empty slice as inputs is equivalent,
 // both gets interpreted as the empty slice.
 func NewCreateRawTransactionCmd(inputs []TransactionInput, amounts map[string]float64,
-	lockTime *int64) *CreateRawTransactionCmd {
+	lockTime *int64, posDataInput *PosDataInput) *CreateRawTransactionCmd {
 	// to make sure we're serializing this to the empty list and not null, we
 	// explicitly initialize the list
 	if inputs == nil {
@@ -78,6 +89,7 @@ func NewCreateRawTransactionCmd(inputs []TransactionInput, amounts map[string]fl
 		Inputs:   inputs,
 		Amounts:  amounts,
 		LockTime: lockTime,
+		PosData:  posDataInput,
 	}
 }
 
@@ -874,6 +886,7 @@ func (a *AllowHighFeesOrMaxFeeRate) UnmarshalJSON(data []byte) error {
 type SendRawTransactionCmd struct {
 	HexTx      string
 	FeeSetting *AllowHighFeesOrMaxFeeRate `jsonrpcdefault:"false"`
+	HexData    *string
 }
 
 // NewSendRawTransactionCmd returns a new instance which can be used to issue a
@@ -881,12 +894,13 @@ type SendRawTransactionCmd struct {
 //
 // The parameters which are pointers indicate they are optional.  Passing nil
 // for optional parameters will use the default value.
-func NewSendRawTransactionCmd(hexTx string, allowHighFees *bool) *SendRawTransactionCmd {
+func NewSendRawTransactionCmd(hexTx string, allowHighFees *bool, hexData *string) *SendRawTransactionCmd {
 	return &SendRawTransactionCmd{
 		HexTx: hexTx,
 		FeeSetting: &AllowHighFeesOrMaxFeeRate{
 			Value: allowHighFees,
 		},
+		HexData: hexData,
 	}
 }
 

--- a/rpcclient/rawtransactions.go
+++ b/rpcclient/rawtransactions.go
@@ -297,7 +297,8 @@ func (c *Client) CreateRawTransactionAsync(inputs []btcjson.TransactionInput,
 	for addr, amount := range amounts {
 		convertedAmts[addr.String()] = amount.ToBTC()
 	}
-	cmd := btcjson.NewCreateRawTransactionCmd(inputs, convertedAmts, lockTime)
+	// TODO-Babylon: Update to pass also commitment data
+	cmd := btcjson.NewCreateRawTransactionCmd(inputs, convertedAmts, lockTime, nil)
 	return c.SendCmd(cmd)
 }
 
@@ -371,7 +372,8 @@ func (c *Client) SendRawTransactionAsync(tx *wire.MsgTx, allowHighFees bool) Fut
 
 	// Otherwise, use the AllowHighFees field.
 	default:
-		cmd = btcjson.NewSendRawTransactionCmd(txHex, &allowHighFees)
+		// TODO-Babylon: Update to pass also commitment data
+		cmd = btcjson.NewSendRawTransactionCmd(txHex, &allowHighFees, nil)
 	}
 
 	return c.SendCmd(cmd)

--- a/rpcserverhelp.go
+++ b/rpcserverhelp.go
@@ -44,6 +44,13 @@ var helpDescsEnUS = map[string]string{
 	"transactioninput-txid": "The hash of the input transaction",
 	"transactioninput-vout": "The specific output of the input transaction to redeem",
 
+	// PosDataInput help.
+	"posdatainput-tag":             "Hex encoded byte string which must have 32 bytes identifing commitment",
+	"posdatainput-hashOrData":      "Based on protectionLevel it should be either hex encoded data or hex encdoed hash of data",
+	"posdatainput-protectionLevel": "if its 0, there will be no data attached to commtiment and hashOrData should have 32bytes, otherwise data provided in hasOrData will be hashed",
+	"posdatainput-nonce":           "Nonce used for ordering of commitments",
+	"posdatainput-posSignature":    "Hex encoded pos signature over all fields; max 128 bytes",
+
 	// CreateRawTransactionCmd help.
 	"createrawtransaction--synopsis": "Returns a new transaction spending the provided inputs and sending to the provided addresses.\n" +
 		"The transaction inputs are not signed in the created transaction.\n" +
@@ -54,6 +61,7 @@ var helpDescsEnUS = map[string]string{
 	"createrawtransaction-amounts--value": "n.nnn",
 	"createrawtransaction-amounts--desc":  "The destination address as the key and the amount in BTC as the value",
 	"createrawtransaction-locktime":       "Locktime value; a non-zero value will also locktime-activate the inputs",
+	"createrawtransaction-posdata":        "Optional data required to create commitment to proof of stake data",
 	"createrawtransaction--result0":       "Hex-encoded bytes of the serialized transaction",
 
 	// ScriptSig help.
@@ -566,6 +574,7 @@ var helpDescsEnUS = map[string]string{
 	"sendrawtransaction--synopsis":    "Submits the serialized, hex-encoded transaction to the local peer and relays it to the network.",
 	"sendrawtransaction-hextx":        "Serialized, hex-encoded signed transaction",
 	"sendrawtransaction-feesetting":   "Whether or not to allow insanely high fees in bitcoind < v0.19.0 or the max fee rate for bitcoind v0.19.0 and later (btcd does not yet implement this parameter, so it has no effect)",
+	"sendrawtransaction-hexdata":      "hexencoded data which should match data whihc is declared in transaction commitment",
 	"sendrawtransaction--result0":     "The hash of the transaction",
 	"allowhighfeesormaxfeerate-value": "Either the boolean value for the allowhighfees parameter in bitcoind < v0.19.0 or the numerical value for the maxfeerate field in bitcoind v0.19.0 and later",
 


### PR DESCRIPTION
Updata json rpc methods to accept optional params related to commitments.

With this pr we should be able to send tx with commitments across network between nodes memory pools, although current lack integration tests does not inspire trusts if everything really works as necessary