### PR TITLE
Remove bitcoin hardcoded DNS seeds

### DIFF
--- a/chaincfg/params.go
+++ b/chaincfg/params.go
@@ -58,11 +58,7 @@ var (
 
 	// DefaultSignetDNSSeeds is the list of seed nodes for the default
 	// (public, Taproot enabled) signet network.
-	DefaultSignetDNSSeeds = []DNSSeed{
-		{"178.128.221.177", false},
-		{"2a01:7c8:d005:390::5", false},
-		{"v7ajjeirttkbnt32wpy3c6w3emwnfr3fkla7hpxcfokr3ysd3kqtzmqd.onion:38333", false},
-	}
+	DefaultSignetDNSSeeds = []DNSSeed{}
 )
 
 // Checkpoint identifies a known good point in the block chain.  Using
@@ -270,14 +266,7 @@ var MainNetParams = Params{
 	Name:        "mainnet",
 	Net:         wire.MainNet,
 	DefaultPort: "8333",
-	DNSSeeds: []DNSSeed{
-		{"seed.bitcoin.sipa.be", true},
-		{"dnsseed.bluematt.me", true},
-		{"dnsseed.bitcoin.dashjr.org", false},
-		{"seed.bitcoinstats.com", true},
-		{"seed.bitnodes.io", false},
-		{"seed.bitcoin.jonasschnelli.ch", true},
-	},
+	DNSSeeds: []DNSSeed{},
 
 	// Chain parameters
 	GenesisBlock:             &genesisBlock,
@@ -473,12 +462,7 @@ var TestNet3Params = Params{
 	Name:        "testnet3",
 	Net:         wire.TestNet3,
 	DefaultPort: "18333",
-	DNSSeeds: []DNSSeed{
-		{"testnet-seed.bitcoin.jonasschnelli.ch", true},
-		{"testnet-seed.bitcoin.schildbach.de", false},
-		{"seed.tbtc.petertodd.org", true},
-		{"testnet-seed.bluematt.me", false},
-	},
+	DNSSeeds: []DNSSeed{},
 
 	// Chain parameters
 	GenesisBlock:             &testNet3GenesisBlock,


### PR DESCRIPTION
These DNS seeds are should not exist in the codebase since they correspond to bitcoin nodes.