### PR TITLE
wire: change type of `HashCommitment` to `chainhash.Hash`

### DIFF
--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -5,8 +5,6 @@
 package blockchain
 
 import (
-	"bytes"
-	"crypto/sha256"
 	"encoding/binary"
 	"fmt"
 	"math"
@@ -221,9 +219,9 @@ func CheckTransactionCommitment(tx *btcutil.Tx, posData []byte) error {
 			return ruleError(ErrMalformedPosCommitment, "data larger than maximum")
 		}
 
-		hash := sha256.Sum256(posData)
+		hash := chainhash.HashH(posData)
 
-		if !bytes.Equal(hash[:], tx.MsgTx().PosCommitment.HashCommitment[:]) {
+		if !hash.IsEqual(&tx.MsgTx().PosCommitment.HashCommitment) {
 			return ruleError(ErrMalformedPosCommitment, "hash of data do not match commitment")
 		}
 

--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -5,7 +5,6 @@
 package mempool
 
 import (
-	"crypto/sha256"
 	"encoding/hex"
 	"math/rand"
 	"reflect"
@@ -1858,7 +1857,7 @@ func validCommitmentForData(d []byte) *wire.Commitmment {
 	// we need protection level 1 to validate hashes
 	comm := wire.NewTxCommitmentVerProtLevel(0, 1)
 	comm.DataSize = uint32(len(d))
-	comm.HashCommitment = sha256.Sum256(d)
+	comm.HashCommitment = chainhash.HashH(d)
 	return comm
 }
 

--- a/wire/msgtx.go
+++ b/wire/msgtx.go
@@ -407,7 +407,7 @@ func NewTxCommitment(
 	version uint8,
 	protectionLevel uint8,
 	dataSize uint32,
-	hashCommitment [chainhash.HashSize]uint8,
+	hashCommitment chainhash.Hash,
 	nonce uint32,
 	signature []uint8) *Commitmment {
 

--- a/wire/msgtx.go
+++ b/wire/msgtx.go
@@ -308,7 +308,7 @@ type Commitmment struct {
 	Tag            [TagSize]uint8
 	verProt        uint8
 	DataSize       uint32
-	HashCommitment [chainhash.HashSize]uint8
+	HashCommitment chainhash.Hash
 	Nonce          uint32
 	PosSig         []uint8
 }


### PR DESCRIPTION
Here `[chainhash.HashSize]uint8` actually means the same thing as `chainhash.Hash`, and `chainhash.Hash` is the typical way of referring a hash type.
The project can build and pass all existing tests after this modification.