### PR TITLE
gitignore: ignore compiled binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,9 @@ coverage.txt
 btcec/coverage.txt
 btcutil/coverage.txt
 btcutil/psbt/coverage.txt
+
+addblock
+bbld
+btcctl
+findcheckpoint
+gencerts


### PR DESCRIPTION
Not sure if we need to add binaries to `.gitignore`. Although the original `btcd` implementation does not ignore them, ignoring them seems necessary as the binary depends on OS/arch and is quite big (e.g., several MBs).