### PR TITLE
doc: add some comments on `Commitment`

### DIFF
--- a/wire/commitmentconst.go
+++ b/wire/commitmentconst.go
@@ -6,7 +6,7 @@ const (
 	// Maximal size of tag stored in commitment
 	TagSize = 32
 
-	// TODO define what should be final data size
+	// TODO-Babylon: define what should be final data size
 	MaxPosDataSize = 50000
 
 	// Maximum size of Proof of stake chain signature

--- a/wire/msgtx.go
+++ b/wire/msgtx.go
@@ -305,8 +305,8 @@ func NewTxOut(value int64, pkScript []byte) *TxOut {
 }
 
 // Commitment is a commitment submitted by a node in the PoS chain checkpointed
-// by Babylon. Each transaction may contain a commitment (field `PosCommitment`
-// in `MsgTx`). The PoS chain will scan and verify checkpoints in Babylon, and
+// by Babylon. Each transaction may contain a commitment (field PosCommitment
+// in MsgTx). The PoS chain will scan and verify checkpoints in Babylon, and
 // execute consensus according to these checkpoints.
 type Commitmment struct {
 	// Tag is a tag that allows PoS chains to search for its own commitment,

--- a/wire/msgtx.go
+++ b/wire/msgtx.go
@@ -305,7 +305,9 @@ func NewTxOut(value int64, pkScript []byte) *TxOut {
 }
 
 // Commitment is a commitment submitted by a node in the PoS chain checkpointed
-// by Babylon.
+// by Babylon. Each transaction may contain a commitment (field `PosCommitment`
+// in `MsgTx`). The PoS chain will scan and verify checkpoints in Babylon, and
+// execute consensus according to these checkpoints.
 type Commitmment struct {
 	// Tag is a tag that allows PoS chains to search for its own commitment,
 	// e.g, a smart contract address of 20 bytes excluding the prefix. The

--- a/wire/msgtxdata.go
+++ b/wire/msgtxdata.go
@@ -1,6 +1,6 @@
 package wire
 
-// TODO decide on licensing
+// TODO-Babylon: decide on licensing
 
 import (
 	"fmt"
@@ -20,7 +20,7 @@ func (msg *MsgTxData) BtcDecode(r io.Reader, pver uint32, enc MessageEncoding) e
 		return err
 	}
 
-	// TODO decide if we want to validate datasize against transaciton commitent here
+	// TODO-Babylon: decide if we want to validate datasize against transaciton commitent here
 	msg.Data, err = ReadVarBytes(r, pver, MaxPosDataSize, "txdata data")
 
 	return err
@@ -40,7 +40,7 @@ func (msg *MsgTxData) BtcEncode(w io.Writer, pver uint32, enc MessageEncoding) e
 		return err
 	}
 
-	// TODO decide if we want to validate datasize against transaciton commitent here
+	// TODO-Babylon: decide if we want to validate datasize against transaciton commitent here
 	return WriteVarBytes(w, pver, msg.Data)
 }
 


### PR DESCRIPTION
I was reading the new code on commitments together with [the Confluence page](https://babylon-chain.atlassian.net/wiki/spaces/BABYLON/pages/294950/1.+Block+Format). During this process I transferred the content in the page to the comments in the code. It might be helpful for early developments and we need it in the future anyway.