### PR TITLE
Add integration tests for transaction with commitments

### DIFF
--- a/btcjson/chainsvrcmds.go
+++ b/btcjson/chainsvrcmds.go
@@ -908,12 +908,13 @@ func NewSendRawTransactionCmd(hexTx string, allowHighFees *bool, hexData *string
 // sendrawtransaction JSON-RPC command to a bitcoind node.
 //
 // A 0 maxFeeRate indicates that a maximum fee rate won't be enforced.
-func NewBitcoindSendRawTransactionCmd(hexTx string, maxFeeRate int32) *SendRawTransactionCmd {
+func NewBitcoindSendRawTransactionCmd(hexTx string, maxFeeRate int32, hexData *string) *SendRawTransactionCmd {
 	return &SendRawTransactionCmd{
 		HexTx: hexTx,
 		FeeSetting: &AllowHighFeesOrMaxFeeRate{
 			Value: &maxFeeRate,
 		},
+		HexData: hexData,
 	}
 }
 

--- a/btcjson/chainsvrcmds_test.go
+++ b/btcjson/chainsvrcmds_test.go
@@ -1281,7 +1281,7 @@ func TestChainSvrCmds(t *testing.T) {
 				return btcjson.NewCmd("sendrawtransaction", "1122", &btcjson.AllowHighFeesOrMaxFeeRate{Value: btcjson.Int32(1234)})
 			},
 			staticCmd: func() interface{} {
-				return btcjson.NewBitcoindSendRawTransactionCmd("1122", 1234)
+				return btcjson.NewBitcoindSendRawTransactionCmd("1122", 1234, nil)
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"sendrawtransaction","params":["1122",1234],"id":1}`,
 			unmarshalled: &btcjson.SendRawTransactionCmd{

--- a/integration/bip0009_test.go
+++ b/integration/bip0009_test.go
@@ -162,7 +162,7 @@ func testBIP0009(t *testing.T, forkKey string, deploymentID uint32) {
 	// still defined and did NOT move to started.
 	confirmationWindow := r.ActiveNet.MinerConfirmationWindow
 	for i := uint32(0); i < confirmationWindow-2; i++ {
-		_, err := r.GenerateAndSubmitBlock(nil, vbLegacyBlockVersion,
+		_, err := r.GenerateAndSubmitBlock(nil, nil, vbLegacyBlockVersion,
 			time.Time{})
 		if err != nil {
 			t.Fatalf("failed to generated block %d: %v", i, err)
@@ -177,7 +177,7 @@ func testBIP0009(t *testing.T, forkKey string, deploymentID uint32) {
 	//
 	// Assert the chain height is the expected value and the soft fork
 	// status is started.
-	_, err = r.GenerateAndSubmitBlock(nil, vbLegacyBlockVersion, time.Time{})
+	_, err = r.GenerateAndSubmitBlock(nil, nil, vbLegacyBlockVersion, time.Time{})
 	if err != nil {
 		t.Fatalf("failed to generated block: %v", err)
 	}
@@ -202,14 +202,14 @@ func testBIP0009(t *testing.T, forkKey string, deploymentID uint32) {
 	}
 	signalForkVersion := int32(1<<deployment.BitNumber) | vbTopBits
 	for i := uint32(0); i < activationThreshold-1; i++ {
-		_, err := r.GenerateAndSubmitBlock(nil, signalForkVersion,
+		_, err := r.GenerateAndSubmitBlock(nil, nil, signalForkVersion,
 			time.Time{})
 		if err != nil {
 			t.Fatalf("failed to generated block %d: %v", i, err)
 		}
 	}
 	for i := uint32(0); i < confirmationWindow-(activationThreshold-1); i++ {
-		_, err := r.GenerateAndSubmitBlock(nil, vbLegacyBlockVersion,
+		_, err := r.GenerateAndSubmitBlock(nil, nil, vbLegacyBlockVersion,
 			time.Time{})
 		if err != nil {
 			t.Fatalf("failed to generated block %d: %v", i, err)
@@ -227,14 +227,14 @@ func testBIP0009(t *testing.T, forkKey string, deploymentID uint32) {
 	// Assert the chain height is the expected value and the soft fork
 	// status moved to locked in.
 	for i := uint32(0); i < activationThreshold; i++ {
-		_, err := r.GenerateAndSubmitBlock(nil, signalForkVersion,
+		_, err := r.GenerateAndSubmitBlock(nil, nil, signalForkVersion,
 			time.Time{})
 		if err != nil {
 			t.Fatalf("failed to generated block %d: %v", i, err)
 		}
 	}
 	for i := uint32(0); i < confirmationWindow-activationThreshold; i++ {
-		_, err := r.GenerateAndSubmitBlock(nil, vbLegacyBlockVersion,
+		_, err := r.GenerateAndSubmitBlock(nil, nil, vbLegacyBlockVersion,
 			time.Time{})
 		if err != nil {
 			t.Fatalf("failed to generated block %d: %v", i, err)
@@ -252,7 +252,7 @@ func testBIP0009(t *testing.T, forkKey string, deploymentID uint32) {
 	// Assert the chain height is the expected value and the soft fork
 	// status is still locked in and did NOT move to active.
 	for i := uint32(0); i < confirmationWindow-1; i++ {
-		_, err := r.GenerateAndSubmitBlock(nil, vbLegacyBlockVersion,
+		_, err := r.GenerateAndSubmitBlock(nil, nil, vbLegacyBlockVersion,
 			time.Time{})
 		if err != nil {
 			t.Fatalf("failed to generated block %d: %v", i, err)
@@ -268,7 +268,7 @@ func testBIP0009(t *testing.T, forkKey string, deploymentID uint32) {
 	//
 	// Assert the chain height is the expected value and the soft fork
 	// status moved to active.
-	_, err = r.GenerateAndSubmitBlock(nil, vbLegacyBlockVersion, time.Time{})
+	_, err = r.GenerateAndSubmitBlock(nil, nil, vbLegacyBlockVersion, time.Time{})
 	if err != nil {
 		t.Fatalf("failed to generated block: %v", err)
 	}
@@ -298,7 +298,7 @@ func testBIP0009(t *testing.T, forkKey string, deploymentID uint32) {
 		}
 
 		_, err := r.GenerateAndSubmitBlock(
-			nil, signalForkVersion, time.Time{},
+			nil, nil, signalForkVersion, time.Time{},
 		)
 		if err != nil {
 			t.Fatalf("failed to generated block %d: %v", i, err)

--- a/integration/csv_fork_test.go
+++ b/integration/csv_fork_test.go
@@ -179,7 +179,7 @@ func TestBIP0113Activation(t *testing.T) {
 	// However, since the block validation consensus rules haven't yet
 	// activated, a block including the transaction should be accepted.
 	txns := []*btcutil.Tx{btcutil.NewTx(tx)}
-	block, err := r.GenerateAndSubmitBlock(txns, -1, time.Time{})
+	block, err := r.GenerateAndSubmitBlock(txns, nil, -1, time.Time{})
 	if err != nil {
 		t.Fatalf("unable to submit block: %v", err)
 	}
@@ -268,7 +268,7 @@ func TestBIP0113Activation(t *testing.T) {
 		}
 
 		txns = []*btcutil.Tx{btcutil.NewTx(tx)}
-		_, err := r.GenerateAndSubmitBlock(txns, -1, time.Time{})
+		_, err := r.GenerateAndSubmitBlock(txns, nil, -1, time.Time{})
 		if err == nil && timeLockDelta >= 0 {
 			t.Fatal("block should be rejected due to non-final " +
 				"txn, but was accepted")
@@ -480,7 +480,7 @@ func TestBIP0068AndBIP0112Activation(t *testing.T) {
 		// generated block as CSV validation for scripts within blocks
 		// shouldn't yet be active.
 		txns := []*btcutil.Tx{btcutil.NewTx(spendingTx)}
-		block, err := r.GenerateAndSubmitBlock(txns, -1, time.Time{})
+		block, err := r.GenerateAndSubmitBlock(txns, nil, -1, time.Time{})
 		if err != nil {
 			t.Fatalf("unable to submit block: %v", err)
 		}
@@ -559,7 +559,7 @@ func TestBIP0068AndBIP0112Activation(t *testing.T) {
 	}
 	for i := 0; i < relativeBlockLock; i++ {
 		timeStamp := prevBlock.Header.Timestamp.Add(time.Minute * 10)
-		b, err := r.GenerateAndSubmitBlock(nil, -1, timeStamp)
+		b, err := r.GenerateAndSubmitBlock(nil, nil, -1, timeStamp)
 		if err != nil {
 			t.Fatalf("unable to generate block: %v", err)
 		}
@@ -677,7 +677,7 @@ func TestBIP0068AndBIP0112Activation(t *testing.T) {
 		// with the non-final transaction. It should be rejected.
 		if !test.accept {
 			txns := []*btcutil.Tx{btcutil.NewTx(test.tx)}
-			_, err := r.GenerateAndSubmitBlock(txns, -1, time.Time{})
+			_, err := r.GenerateAndSubmitBlock(txns, nil, -1, time.Time{})
 			if err == nil {
 				t.Fatalf("test #%d, invalid block accepted", i)
 			}

--- a/integration/csv_fork_test.go
+++ b/integration/csv_fork_test.go
@@ -54,7 +54,7 @@ func makeTestOutput(r *rpctest.Harness, t *testing.T,
 	output := &wire.TxOut{PkScript: selfAddrScript, Value: 1e8}
 
 	// Next, create and broadcast a transaction paying to the output.
-	fundTx, err := r.CreateTransaction([]*wire.TxOut{output}, 10, true)
+	fundTx, err := r.CreateTransaction([]*wire.TxOut{output}, 10, true, nil)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -317,7 +317,7 @@ func createCSVOutput(r *rpctest.Harness, t *testing.T,
 
 	// Finally create a valid transaction which creates the output crafted
 	// above.
-	tx, err := r.CreateTransaction([]*wire.TxOut{output}, 10, true)
+	tx, err := r.CreateTransaction([]*wire.TxOut{output}, 10, true, nil)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/integration/rpctest/blockgen.go
+++ b/integration/rpctest/blockgen.go
@@ -133,7 +133,7 @@ func createCoinbaseTx(coinbaseScript []byte, nextBlockHeight int32,
 // initialized), then the timestamp of the previous block will be used plus 1
 // second is used. Passing nil for the previous block results in a block that
 // builds off of the genesis block for the specified chain.
-func CreateBlock(prevBlock *btcutil.Block, inclusionTxs []*btcutil.Tx,
+func CreateBlock(prevBlock *btcutil.Block, inclusionTxs []*btcutil.Tx, inclusionData [][]byte,
 	blockVersion int32, blockTime time.Time, miningAddr btcutil.Address,
 	mineTo []wire.TxOut, net *chaincfg.Params) (*btcutil.Block, error) {
 
@@ -208,6 +208,12 @@ func CreateBlock(prevBlock *btcutil.Block, inclusionTxs []*btcutil.Tx,
 	}
 	for _, tx := range blockTxns {
 		if err := block.AddTransaction(tx.MsgTx()); err != nil {
+			return nil, err
+		}
+	}
+
+	for _, data := range inclusionData {
+		if err := block.AddData(data); err != nil {
 			return nil, err
 		}
 	}

--- a/integration/rpctest/memwallet.go
+++ b/integration/rpctest/memwallet.go
@@ -489,9 +489,7 @@ func (m *memWallet) CreateTransaction(outputs []*wire.TxOut,
 
 	tx := wire.NewMsgTx(wire.TxVersion)
 
-	if commitment != nil {
-		tx.PosCommitment = commitment
-	}
+	tx.PosCommitment = commitment
 
 	// Tally up the total amount to be sent in order to perform coin
 	// selection shortly below.

--- a/integration/rpctest/rpc_harness.go
+++ b/integration/rpctest/rpc_harness.go
@@ -387,12 +387,6 @@ func (h *Harness) ConfirmedBalance() btcutil.Amount {
 //
 // This function is safe for concurrent access.
 func (h *Harness) SendOutputs(targetOutputs []*wire.TxOut,
-	feeRate btcutil.Amount) (*chainhash.Hash, error) {
-
-	return h.wallet.SendOutputs(targetOutputs, feeRate, nil)
-}
-
-func (h *Harness) SendOutputsWithCommitment(targetOutputs []*wire.TxOut,
 	feeRate btcutil.Amount, comm *wire.Commitmment) (*chainhash.Hash, error) {
 
 	return h.wallet.SendOutputs(targetOutputs, feeRate, comm)
@@ -404,12 +398,6 @@ func (h *Harness) SendOutputsWithCommitment(targetOutputs []*wire.TxOut,
 //
 // This function is safe for concurrent access.
 func (h *Harness) SendOutputsWithoutChange(targetOutputs []*wire.TxOut,
-	feeRate btcutil.Amount) (*chainhash.Hash, error) {
-
-	return h.wallet.SendOutputsWithoutChange(targetOutputs, feeRate, nil)
-}
-
-func (h *Harness) SendOutputsWithoutChangeWithCommitment(targetOutputs []*wire.TxOut,
 	feeRate btcutil.Amount, comm *wire.Commitmment) (*chainhash.Hash, error) {
 
 	return h.wallet.SendOutputsWithoutChange(targetOutputs, feeRate, comm)
@@ -427,13 +415,6 @@ func (h *Harness) SendOutputsWithoutChangeWithCommitment(targetOutputs []*wire.T
 //
 // This function is safe for concurrent access.
 func (h *Harness) CreateTransaction(targetOutputs []*wire.TxOut,
-	feeRate btcutil.Amount, change bool) (*wire.MsgTx, error) {
-
-	return h.wallet.CreateTransaction(targetOutputs, feeRate, change, nil)
-}
-
-// This function is safe for concurrent access.
-func (h *Harness) CreateTransactionWithCommitment(targetOutputs []*wire.TxOut,
 	feeRate btcutil.Amount, change bool, comm *wire.Commitmment) (*wire.MsgTx, error) {
 
 	return h.wallet.CreateTransaction(targetOutputs, feeRate, change, comm)

--- a/integration/rpctest/rpc_harness_test.go
+++ b/integration/rpctest/rpc_harness_test.go
@@ -36,7 +36,7 @@ func testSendOutputs(r *Harness, t *testing.T) {
 			t.Fatalf("unable to generate pkscript to addr: %v", err)
 		}
 		output := wire.NewTxOut(int64(amt), addrScript)
-		txid, err := r.SendOutputs([]*wire.TxOut{output}, 10)
+		txid, err := r.SendOutputs([]*wire.TxOut{output}, 10, nil)
 		if err != nil {
 			t.Fatalf("coinbase spend failed: %v", err)
 		}
@@ -207,7 +207,7 @@ func testJoinMempools(r *Harness, t *testing.T) {
 		t.Fatalf("unable to generate pkscript to addr: %v", err)
 	}
 	output := wire.NewTxOut(5e8, addrScript)
-	testTx, err := r.CreateTransaction([]*wire.TxOut{output}, 10, true)
+	testTx, err := r.CreateTransaction([]*wire.TxOut{output}, 10, true, nil)
 	if err != nil {
 		t.Fatalf("coinbase spend failed: %v", err)
 	}
@@ -341,7 +341,7 @@ func testGenerateAndSubmitBlock(r *Harness, t *testing.T) {
 	const numTxns = 5
 	txns := make([]*btcutil.Tx, 0, numTxns)
 	for i := 0; i < numTxns; i++ {
-		tx, err := r.CreateTransaction([]*wire.TxOut{output}, 10, true)
+		tx, err := r.CreateTransaction([]*wire.TxOut{output}, 10, true, nil)
 		if err != nil {
 			t.Fatalf("unable to create tx: %v", err)
 		}
@@ -408,7 +408,7 @@ func testGenerateAndSubmitBlockWithCustomCoinbaseOutputs(r *Harness,
 	const numTxns = 5
 	txns := make([]*btcutil.Tx, 0, numTxns)
 	for i := 0; i < numTxns; i++ {
-		tx, err := r.CreateTransaction([]*wire.TxOut{output}, 10, true)
+		tx, err := r.CreateTransaction([]*wire.TxOut{output}, 10, true, nil)
 		if err != nil {
 			t.Fatalf("unable to create tx: %v", err)
 		}
@@ -523,7 +523,7 @@ func testMemWalletLockedOutputs(r *Harness, t *testing.T) {
 	}
 	outputAmt := btcutil.Amount(50 * btcutil.SatoshiPerBitcoin)
 	output := wire.NewTxOut(int64(outputAmt), pkScript)
-	tx, err := r.CreateTransaction([]*wire.TxOut{output}, 10, true)
+	tx, err := r.CreateTransaction([]*wire.TxOut{output}, 10, true, nil)
 	if err != nil {
 		t.Fatalf("unable to create transaction: %v", err)
 	}

--- a/integration/rpctest/rpc_harness_test.go
+++ b/integration/rpctest/rpc_harness_test.go
@@ -351,7 +351,7 @@ func testGenerateAndSubmitBlock(r *Harness, t *testing.T) {
 
 	// Now generate a block with the default block version, and a zero'd
 	// out time.
-	block, err := r.GenerateAndSubmitBlock(txns, -1, time.Time{})
+	block, err := r.GenerateAndSubmitBlock(txns, nil, -1, time.Time{})
 	if err != nil {
 		t.Fatalf("unable to generate block: %v", err)
 	}
@@ -373,7 +373,7 @@ func testGenerateAndSubmitBlock(r *Harness, t *testing.T) {
 	// time stamp a minute after the previous block's timestamp.
 	timestamp := block.MsgBlock().Header.Timestamp.Add(time.Minute)
 	targetBlockVersion := int32(1337)
-	block, err = r.GenerateAndSubmitBlock(nil, targetBlockVersion, timestamp)
+	block, err = r.GenerateAndSubmitBlock(nil, nil, targetBlockVersion, timestamp)
 	if err != nil {
 		t.Fatalf("unable to generate block: %v", err)
 	}
@@ -418,7 +418,7 @@ func testGenerateAndSubmitBlockWithCustomCoinbaseOutputs(r *Harness,
 
 	// Now generate a block with the default block version, a zero'd out
 	// time, and a burn output.
-	block, err := r.GenerateAndSubmitBlockWithCustomCoinbaseOutputs(txns,
+	block, err := r.GenerateAndSubmitBlockWithCustomCoinbaseOutputs(txns, nil,
 		-1, time.Time{}, []wire.TxOut{{
 			Value:    0,
 			PkScript: []byte{},
@@ -444,7 +444,7 @@ func testGenerateAndSubmitBlockWithCustomCoinbaseOutputs(r *Harness,
 	// time stamp a minute after the previous block's timestamp.
 	timestamp := block.MsgBlock().Header.Timestamp.Add(time.Minute)
 	targetBlockVersion := int32(1337)
-	block, err = r.GenerateAndSubmitBlockWithCustomCoinbaseOutputs(nil,
+	block, err = r.GenerateAndSubmitBlockWithCustomCoinbaseOutputs(nil, nil,
 		targetBlockVersion, timestamp, []wire.TxOut{{
 			Value:    0,
 			PkScript: []byte{},

--- a/integration/transactiontest/rpc_transaction_test.go
+++ b/integration/transactiontest/rpc_transaction_test.go
@@ -1,0 +1,525 @@
+package transactiontest
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"runtime/debug"
+	"testing"
+	"time"
+
+	"github.com/babylonchain-io/bbld/btcjson"
+	"github.com/babylonchain-io/bbld/btcutil"
+	"github.com/babylonchain-io/bbld/chaincfg"
+	"github.com/babylonchain-io/bbld/chaincfg/chainhash"
+	"github.com/babylonchain-io/bbld/integration/rpctest"
+	"github.com/babylonchain-io/bbld/txscript"
+	"github.com/babylonchain-io/bbld/wire"
+)
+
+func contains(hashes []*chainhash.Hash, hash *chainhash.Hash) bool {
+	for _, h := range hashes {
+		if h.IsEqual(hash) {
+			return true
+		}
+	}
+	return false
+}
+
+func generateRadomBytes(n int) []byte {
+	var b = make([]byte, n)
+	rand.Read(b)
+	return b
+}
+
+func generateRandomBytesString(n int) string {
+	return hex.EncodeToString(generateRadomBytes(n))
+}
+
+func getCoinbaseHash(r *rpctest.Harness, bNum int) (*chainhash.Hash, error) {
+	bh, err := r.Client.GetBlockHash(int64(bNum))
+	if err != nil {
+		return nil, err
+	}
+
+	block, err := r.Client.GetBlock(bh)
+
+	if err != nil {
+		return nil, err
+	}
+
+	// it will panic if block does not have coinbase, but it is fine as every block
+	// should have coinbase, if it does not we are doing something seriously wrong
+	hash := block.Transactions[0].TxHash()
+
+	return &hash, nil
+}
+
+func getBestBlock(r *rpctest.Harness) (*btcutil.Block, error) {
+	bh, _, err := r.Client.GetBestBlock()
+	if err != nil {
+		return nil, err
+	}
+
+	block, err := r.Client.GetBlock(bh)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return btcutil.NewBlock(block), nil
+}
+
+func assertInputAgainstCommitment(t *testing.T, input *btcjson.PosDataInput, comm *wire.Commitmment) {
+	if input == nil && comm == nil {
+		return
+	}
+
+	if input == nil && comm != nil {
+		t.Fatal("Received commitment for nil input")
+	}
+
+	if input != nil && comm == nil {
+		t.Fatal("Expected non nil commitment")
+	}
+
+	tagBytes, _ := hex.DecodeString(input.Tag)
+	if !bytes.Equal(tagBytes, comm.Tag[:]) {
+		t.Fatal("Tag bytes of commitment do not match input")
+	}
+
+	if input.ProtectionLevel != comm.ProtectionLevel() {
+		t.Fatal("Commitment protection level do not match input")
+	}
+
+	sigBytes, _ := hex.DecodeString(input.PosSig)
+	if !bytes.Equal(sigBytes, comm.PosSig) {
+		t.Fatal("Pos signature of commitment do not match input")
+	}
+
+	if input.ProtectionLevel == 0 {
+		if comm.DataSize > 0 {
+			t.Fatal("Commitment data size should be 0 with protection level = 0")
+		}
+
+		hashBytes, _ := hex.DecodeString(input.HashOrData)
+
+		if !bytes.Equal(hashBytes, comm.HashCommitment[:]) {
+			t.Fatal("Protection level 0, Commitment hash different than provided")
+		}
+
+	} else if input.ProtectionLevel == 1 {
+		inputBytes, _ := hex.DecodeString(input.HashOrData)
+		if int(comm.DataSize) != len(inputBytes) {
+			t.Fatal("Commitment data size do not match provided data")
+		}
+
+		dataHash := sha256.Sum256(inputBytes)
+
+		if !bytes.Equal(dataHash[:], comm.HashCommitment[:]) {
+			t.Fatal("Hash of commitment should be sha256 hash")
+		}
+
+	} else {
+		t.Fatal("Unexpected input protection level")
+	}
+}
+
+func testCreateTransaction(r *rpctest.Harness, t *testing.T) {
+	// Grab a fresh address from the wallet.
+	addr, err := r.NewAddress()
+	if err != nil {
+		t.Fatalf("unable to get new address: %v", err)
+	}
+
+	coinbaseHash, err := getCoinbaseHash(r, 1)
+
+	if err != nil {
+		t.Fatalf("Unable to get coinbase transaction: %v", err)
+	}
+
+	tin := btcjson.TransactionInput{Txid: coinbaseHash.String(), Vout: 0}
+	am := map[btcutil.Address]btcutil.Amount{addr: 1}
+	inps := []btcjson.TransactionInput{tin}
+
+	posDataInput := btcjson.PosDataInput{
+		Tag:             generateRandomBytesString(32),
+		HashOrData:      generateRandomBytesString(64),
+		ProtectionLevel: 1,
+		Nonce:           0,
+		PosSig:          generateRandomBytesString(64),
+	}
+
+	rawTx, err := r.Client.CreateRawTransaction(inps, am, nil, &posDataInput)
+
+	if err != nil {
+		t.Fatalf("Unable to create rawTx: %v", err)
+	}
+
+	assertInputAgainstCommitment(t, &posDataInput, rawTx.PosCommitment)
+
+	posDataInput1 := btcjson.PosDataInput{
+		Tag:             generateRandomBytesString(32),
+		HashOrData:      generateRandomBytesString(32),
+		ProtectionLevel: 0,
+		Nonce:           0,
+		PosSig:          generateRandomBytesString(64),
+	}
+
+	rawTx1, err := r.Client.CreateRawTransaction(inps, am, nil, &posDataInput1)
+
+	if err != nil {
+		t.Fatalf("Unable to create rawTx: %v", err)
+	}
+
+	assertInputAgainstCommitment(t, &posDataInput1, rawTx1.PosCommitment)
+
+	// TODO Add error paths
+}
+
+func testSendRawTransactionWithCommitment(r *rpctest.Harness, t *testing.T) {
+	// Grab a fresh address from the wallet.
+	addr, err := r.NewAddress()
+	if err != nil {
+		t.Fatalf("unable to get new address: %v", err)
+	}
+
+	addrScript, err := txscript.PayToAddrScript(addr)
+	if err != nil {
+		t.Fatalf("unable to get new address: %v", err)
+	}
+
+	coinbaseHash, err := getCoinbaseHash(r, 1)
+
+	if err != nil {
+		t.Fatalf("Unable to get coinbase transaction: %v", err)
+	}
+
+	tin := btcjson.TransactionInput{Txid: coinbaseHash.String(), Vout: 0}
+	am := map[btcutil.Address]btcutil.Amount{addr: 1e8}
+	inps := []btcjson.TransactionInput{tin}
+
+	commData := generateRandomBytesString(64)
+	dataBytes, _ := hex.DecodeString(commData)
+
+	posDataInput := btcjson.PosDataInput{
+		Tag:             generateRandomBytesString(32),
+		HashOrData:      commData,
+		ProtectionLevel: 1,
+		Nonce:           0,
+		PosSig:          generateRandomBytesString(64),
+	}
+
+	rawTx, err := r.Client.CreateRawTransaction(inps, am, nil, &posDataInput)
+
+	if err != nil {
+		t.Fatalf("Unable to create rawTx: %v", err)
+	}
+
+	output := wire.NewTxOut(5e8, addrScript)
+
+	// TODO-BABYLON It is a little bit hacky as we are re-using commitment created by
+	// createRawTx endpoint in creating transasction by memory wallet. Other alternative
+	// would be to pass coinbase output directly to signing code which also is not pretty.
+	testTx, err := r.CreateTransactionWithCommitment([]*wire.TxOut{output}, 10, true, rawTx.PosCommitment)
+	if err != nil {
+		t.Fatalf("Cannot create tx with commitment: %v", err)
+	}
+
+	txHash, err := r.Client.SendRawTransactionWithData(testTx, false, commData)
+
+	if err != nil {
+		t.Fatalf("Unable to send raw transaction with data: %v", err)
+	}
+
+	mempoolTxs, err := r.Client.GetRawMempool()
+
+	if err != nil {
+		t.Fatalf("Unable to get mempool transactions: %v", err)
+	}
+
+	if !contains(mempoolTxs, txHash) {
+		t.Fatalf("Mempool transactions did not contain sent transaction")
+	}
+
+	txns := make([]*btcutil.Tx, 0, 1)
+	txns = append(txns, btcutil.NewTx(testTx))
+
+	data := make([][]byte, 0, 1)
+	data = append(data, dataBytes)
+
+	// TODO-BABYLON we should probably modify getBlockTemplate endpoint and use it here like
+	// t := r.getBlockTemplate()
+	// block := r.submitBlock(t.transactions, t.data)
+	block, e := r.GenerateAndSubmitBlock(txns, data, -1, time.Time{})
+
+	if e != nil {
+		t.Fatalf("Unable to generate block: %v", e)
+	}
+
+	// we should have at least two transactions, coinbase + transaction from mempool
+	if len(block.Transactions()) != 2 {
+		t.Fatal("Block should contain at leas 2 transactions")
+	}
+
+	if len(block.MsgBlock().PosData) != 1 {
+		t.Fatal("Block should contang at least one piece of data")
+	}
+
+	blockTransactionHash := block.Transactions()[1].Hash()
+
+	if !blockTransactionHash.IsEqual(txHash) {
+		t.Fatal("Unexpected transaction in mined block")
+	}
+
+	mempoolTxs, err = r.Client.GetRawMempool()
+
+	if err != nil {
+		t.Fatalf("Unable to get mempool transactions: %v", err)
+	}
+
+	// After importing block, transaciton in it should be removed from the mempool
+	if len(mempoolTxs) > 0 {
+		t.Fatalf("Mempoool should be empty")
+	}
+
+	// double check that block was really imported in block chain
+	hash, height, err := r.Client.GetBestBlock()
+
+	if err != nil {
+		t.Fatalf("Unable to get best block: %v", err)
+	}
+
+	if !block.Hash().IsEqual(hash) || block.Height() != height {
+		t.Fatal("Best block is not the last imported block")
+	}
+}
+
+// Check that transactionw with commitment and data is properly propagated
+// and then introduced into block
+func testPropagateTxWithData(r *rpctest.Harness, t *testing.T) {
+	// Create a second harness with only the genesis block so it is behind
+	// the main harness.
+	harness, err := rpctest.New(&chaincfg.SimNetParams, nil, nil, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := harness.SetUp(false, 0); err != nil {
+		t.Fatalf("unable to complete rpctest setup: %v", err)
+	}
+	defer harness.TearDown()
+
+	nodeSlice := []*rpctest.Harness{r, harness}
+
+	// Establish an outbound connection from the local harness to the main
+	// harness and wait for the chains to be synced.
+	if err := rpctest.ConnectNode(harness, r); err != nil {
+		t.Fatalf("unable to connect harnesses: %v", err)
+	}
+
+	if err := rpctest.JoinNodes(nodeSlice, rpctest.Blocks); err != nil {
+		t.Fatalf("unable to join node on blocks: %v", err)
+	}
+
+	mainHarnessBestHash, _, e := r.Client.GetBestBlock()
+
+	if e != nil {
+		t.Fatal("Cannot get main node best block")
+	}
+
+	secondHarnessBestHash, _, e := harness.Client.GetBestBlock()
+
+	if e != nil {
+		t.Fatal("Cannot get main node best block")
+	}
+
+	if !mainHarnessBestHash.IsEqual(secondHarnessBestHash) {
+		t.Fatal("Nodes are not synchronized")
+	}
+
+	// Grab a fresh address from the wallet.
+	addr, err := r.NewAddress()
+	if err != nil {
+		t.Fatalf("unable to get new address: %v", err)
+	}
+
+	addrScript, err := txscript.PayToAddrScript(addr)
+	if err != nil {
+		t.Fatalf("unable to get new address: %v", err)
+	}
+
+	output := wire.NewTxOut(5e8, addrScript)
+
+	data := generateRadomBytes(100)
+	dataHash := sha256.Sum256(data)
+	tagBytes := generateRadomBytes(32)
+	var tag [wire.TagSize]byte
+	copy(tag[:], tagBytes)
+
+	sig := generateRadomBytes(64)
+	comm := wire.NewTxCommitment(tag, 0, 1, uint32(len(data)), dataHash, 0, sig)
+
+	testTx, err := r.CreateTransactionWithCommitment([]*wire.TxOut{output}, 10, true, comm)
+	if err != nil {
+		t.Fatalf("Cannot create tx with commitment: %v", err)
+	}
+
+	txHash, err := r.Client.SendRawTransactionWithData(testTx, false, hex.EncodeToString(data))
+
+	if err != nil {
+		t.Fatalf("Unable to send raw transaction with data: %v", err)
+	}
+
+	mempool, err := r.Client.GetRawMempool()
+
+	if err != nil {
+		t.Fatalf("unable to get main node mempoool: %v", err)
+	}
+
+	if !contains(mempool, txHash) {
+		t.Fatal("Main node mempool should contain sent transction")
+	}
+
+	if err := rpctest.JoinNodes(nodeSlice, rpctest.Mempools); err != nil {
+		t.Fatalf("unable to join node on mempool: %v", err)
+	}
+
+	clientNodeMempool, err := harness.Client.GetRawMempool()
+
+	if err != nil {
+		t.Fatalf("unable to get main node mempoool: %v", err)
+	}
+
+	if !contains(clientNodeMempool, txHash) {
+		t.Fatal("Client node mempool should contain sent transction")
+	}
+
+	txns := make([]*btcutil.Tx, 0, 1)
+	txns = append(txns, btcutil.NewTx(testTx))
+
+	blockData := make([][]byte, 0, 1)
+	blockData = append(blockData, data)
+
+	block, err := r.GenerateAndSubmitBlock(txns, blockData, -1, time.Time{})
+
+	if err != nil {
+		t.Fatalf("Unable to sumbmit block to main node: %v", err)
+	}
+
+	bestBlockHash, _, err := r.Client.GetBestBlock()
+
+	if err != nil {
+		t.Fatalf("Unable to get best block of main node: %v", err)
+	}
+
+	if !block.Hash().IsEqual(bestBlockHash) {
+		t.Fatal("Submitted block is not best block")
+	}
+
+	if len(block.Transactions()) != 2 || len(block.MsgBlock().PosData) != 1 {
+		t.Fatal("Best block does not have expected number of data or transactions")
+	}
+
+	// Now new best block should be propagated to client node
+	if err := rpctest.JoinNodes(nodeSlice, rpctest.Blocks); err != nil {
+		t.Fatalf("unable to join node on blocks: %v", err)
+	}
+
+	clientBestBlock, err := getBestBlock(harness)
+
+	if err != nil {
+		t.Fatal("Cannot get client node best block")
+	}
+
+	if !bestBlockHash.IsEqual(clientBestBlock.Hash()) {
+		t.Fatal("Client best block hash is not equal to main node best block hash")
+	}
+
+	clientBestBlockData := clientBestBlock.MsgBlock().PosData[0]
+	clientBestBlockCommitment := clientBestBlock.Transactions()[1].MsgTx().PosCommitment
+
+	if !bytes.Equal(clientBestBlockData, data) {
+		t.Fatal("Client best block does not have expected data")
+	}
+
+	if !bytes.Equal(clientBestBlockCommitment.HashCommitment[:], comm.HashCommitment[:]) {
+		t.Fatal("Client best block does not have expected commitment")
+	}
+
+}
+
+var rpcTestCases = []rpctest.HarnessTestCase{
+	testCreateTransaction,
+	testSendRawTransactionWithCommitment,
+	testPropagateTxWithData,
+}
+
+var primaryHarness *rpctest.Harness
+
+func TestMain(m *testing.M) {
+	var err error
+
+	// In order to properly test scenarios on as if we were on mainnet,
+	// ensure that non-standard transactions aren't accepted into the
+	// mempool or relayed.
+	btcdCfg := []string{"--rejectnonstd"}
+	primaryHarness, err = rpctest.New(
+		&chaincfg.SimNetParams, nil, btcdCfg, "",
+	)
+	if err != nil {
+		fmt.Println("unable to create primary harness: ", err)
+		os.Exit(1)
+	}
+
+	// Initialize the primary mining node with a chain of length 125,
+	// providing 25 mature coinbases to allow spending from for testing
+	// purposes.
+	if err := primaryHarness.SetUp(true, 25); err != nil {
+		fmt.Println("unable to setup test chain: ", err)
+
+		// Even though the harness was not fully setup, it still needs
+		// to be torn down to ensure all resources such as temp
+		// directories are cleaned up.  The error is intentionally
+		// ignored since this is already an error path and nothing else
+		// could be done about it anyways.
+		_ = primaryHarness.TearDown()
+		os.Exit(1)
+	}
+
+	exitCode := m.Run()
+
+	// Clean up any active harnesses that are still currently running.This
+	// includes removing all temporary directories, and shutting down any
+	// created processes.
+	if err := rpctest.TearDownAll(); err != nil {
+		fmt.Println("unable to tear down all harnesses: ", err)
+		os.Exit(1)
+	}
+
+	os.Exit(exitCode)
+}
+
+func TestRpcTransaction(t *testing.T) {
+	var currentTestNum int
+	defer func() {
+		// If one of the integration tests caused a panic within the main
+		// goroutine, then tear down all the harnesses in order to avoid
+		// any leaked btcd processes.
+		if r := recover(); r != nil {
+			fmt.Println("recovering from test panic: ", r)
+			if err := rpctest.TearDownAll(); err != nil {
+				fmt.Println("unable to tear down all harnesses: ", err)
+			}
+			t.Fatalf("test #%v panicked: %s", currentTestNum, debug.Stack())
+		}
+	}()
+
+	for _, testCase := range rpcTestCases {
+		testCase(primaryHarness, t)
+
+		currentTestNum++
+	}
+}

--- a/integration/transactiontest/rpc_transaction_test.go
+++ b/integration/transactiontest/rpc_transaction_test.go
@@ -224,7 +224,7 @@ func testSendRawTransactionWithCommitment(r *rpctest.Harness, t *testing.T) {
 	// TODO-BABYLON It is a little bit hacky as we are re-using commitment created by
 	// createRawTx endpoint in creating transasction by memory wallet. Other alternative
 	// would be to pass coinbase output directly to signing code which also is not pretty.
-	testTx, err := r.CreateTransactionWithCommitment([]*wire.TxOut{output}, 10, true, rawTx.PosCommitment)
+	testTx, err := r.CreateTransaction([]*wire.TxOut{output}, 10, true, rawTx.PosCommitment)
 	if err != nil {
 		t.Fatalf("Cannot create tx with commitment: %v", err)
 	}
@@ -298,7 +298,7 @@ func testSendRawTransactionWithCommitment(r *rpctest.Harness, t *testing.T) {
 	}
 }
 
-// Check that transactionw with commitment and data is properly propagated
+// Check that transaction with commitment and data is properly propagated
 // and then introduced into block
 func testPropagateTxWithData(r *rpctest.Harness, t *testing.T) {
 	// Create a second harness with only the genesis block so it is behind
@@ -324,16 +324,16 @@ func testPropagateTxWithData(r *rpctest.Harness, t *testing.T) {
 		t.Fatalf("unable to join node on blocks: %v", err)
 	}
 
-	mainHarnessBestHash, _, e := r.Client.GetBestBlock()
+	mainHarnessBestHash, _, err := r.Client.GetBestBlock()
 
-	if e != nil {
-		t.Fatal("Cannot get main node best block")
+	if err != nil {
+		t.Fatalf("Cannot get main node best block: %v", err)
 	}
 
-	secondHarnessBestHash, _, e := harness.Client.GetBestBlock()
+	secondHarnessBestHash, _, err := harness.Client.GetBestBlock()
 
-	if e != nil {
-		t.Fatal("Cannot get main node best block")
+	if err != nil {
+		t.Fatalf("Cannot get client node best block: %v", err)
 	}
 
 	if !mainHarnessBestHash.IsEqual(secondHarnessBestHash) {
@@ -362,7 +362,7 @@ func testPropagateTxWithData(r *rpctest.Harness, t *testing.T) {
 	sig := generateRadomBytes(64)
 	comm := wire.NewTxCommitment(tag, 0, 1, uint32(len(data)), dataHash, 0, sig)
 
-	testTx, err := r.CreateTransactionWithCommitment([]*wire.TxOut{output}, 10, true, comm)
+	testTx, err := r.CreateTransaction([]*wire.TxOut{output}, 10, true, comm)
 	if err != nil {
 		t.Fatalf("Cannot create tx with commitment: %v", err)
 	}
@@ -445,10 +445,9 @@ func testPropagateTxWithData(r *rpctest.Harness, t *testing.T) {
 		t.Fatal("Client best block does not have expected data")
 	}
 
-	if !bytes.Equal(clientBestBlockCommitment.HashCommitment[:], comm.HashCommitment[:]) {
+	if !clientBestBlockCommitment.HashCommitment.IsEqual(&comm.HashCommitment) {
 		t.Fatal("Client best block does not have expected commitment")
 	}
-
 }
 
 var rpcTestCases = []rpctest.HarnessTestCase{

--- a/rpcclient/rawtransactions.go
+++ b/rpcclient/rawtransactions.go
@@ -291,14 +291,14 @@ func (r FutureCreateRawTransactionResult) Receive() (*wire.MsgTx, error) {
 //
 // See CreateRawTransaction for the blocking version and more details.
 func (c *Client) CreateRawTransactionAsync(inputs []btcjson.TransactionInput,
-	amounts map[btcutil.Address]btcutil.Amount, lockTime *int64) FutureCreateRawTransactionResult {
+	amounts map[btcutil.Address]btcutil.Amount, lockTime *int64, posDataInput *btcjson.PosDataInput) FutureCreateRawTransactionResult {
 
 	convertedAmts := make(map[string]float64, len(amounts))
 	for addr, amount := range amounts {
 		convertedAmts[addr.String()] = amount.ToBTC()
 	}
 	// TODO-Babylon: Update to pass also commitment data
-	cmd := btcjson.NewCreateRawTransactionCmd(inputs, convertedAmts, lockTime, nil)
+	cmd := btcjson.NewCreateRawTransactionCmd(inputs, convertedAmts, lockTime, posDataInput)
 	return c.SendCmd(cmd)
 }
 
@@ -306,9 +306,9 @@ func (c *Client) CreateRawTransactionAsync(inputs []btcjson.TransactionInput,
 // and sending to the provided addresses. If the inputs are either nil or an
 // empty slice, it is interpreted as an empty slice.
 func (c *Client) CreateRawTransaction(inputs []btcjson.TransactionInput,
-	amounts map[btcutil.Address]btcutil.Amount, lockTime *int64) (*wire.MsgTx, error) {
+	amounts map[btcutil.Address]btcutil.Amount, lockTime *int64, posDataInput *btcjson.PosDataInput) (*wire.MsgTx, error) {
 
-	return c.CreateRawTransactionAsync(inputs, amounts, lockTime).Receive()
+	return c.CreateRawTransactionAsync(inputs, amounts, lockTime, posDataInput).Receive()
 }
 
 // FutureSendRawTransactionResult is a future promise to deliver the result
@@ -339,7 +339,7 @@ func (r FutureSendRawTransactionResult) Receive() (*chainhash.Hash, error) {
 // the returned instance.
 //
 // See SendRawTransaction for the blocking version and more details.
-func (c *Client) SendRawTransactionAsync(tx *wire.MsgTx, allowHighFees bool) FutureSendRawTransactionResult {
+func (c *Client) SendRawTransactionAsync(tx *wire.MsgTx, allowHighFees bool, posData *string) FutureSendRawTransactionResult {
 	txHex := ""
 	if tx != nil {
 		// Serialize the transaction and convert to hex string.
@@ -368,12 +368,12 @@ func (c *Client) SendRawTransactionAsync(tx *wire.MsgTx, allowHighFees bool) Fut
 		if !allowHighFees {
 			maxFeeRate = defaultMaxFeeRate
 		}
-		cmd = btcjson.NewBitcoindSendRawTransactionCmd(txHex, maxFeeRate)
+		cmd = btcjson.NewBitcoindSendRawTransactionCmd(txHex, maxFeeRate, posData)
 
 	// Otherwise, use the AllowHighFees field.
 	default:
 		// TODO-Babylon: Update to pass also commitment data
-		cmd = btcjson.NewSendRawTransactionCmd(txHex, &allowHighFees, nil)
+		cmd = btcjson.NewSendRawTransactionCmd(txHex, &allowHighFees, posData)
 	}
 
 	return c.SendCmd(cmd)
@@ -382,7 +382,13 @@ func (c *Client) SendRawTransactionAsync(tx *wire.MsgTx, allowHighFees bool) Fut
 // SendRawTransaction submits the encoded transaction to the server which will
 // then relay it to the network.
 func (c *Client) SendRawTransaction(tx *wire.MsgTx, allowHighFees bool) (*chainhash.Hash, error) {
-	return c.SendRawTransactionAsync(tx, allowHighFees).Receive()
+	return c.SendRawTransactionAsync(tx, allowHighFees, nil).Receive()
+}
+
+// SendRawTransaction submits the encoded transaction to the server which will
+// then relay it to the network.
+func (c *Client) SendRawTransactionWithData(tx *wire.MsgTx, allowHighFees bool, posData string) (*chainhash.Hash, error) {
+	return c.SendRawTransactionAsync(tx, allowHighFees, &posData).Receive()
 }
 
 // FutureSignRawTransactionResult is a future promise to deliver the result

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -560,7 +560,7 @@ func decodeCommitment(p *btcjson.PosDataInput) (*wire.Commitmment, error) {
 	if p.ProtectionLevel == 0 {
 		// if protection level is zero, then field HashOrData should be and
 		// hash of some data and data size will be equal to 0
-		if len(hashOrData) > chainhash.HashSize {
+		if len(hashOrData) != chainhash.HashSize {
 			return nil, &btcjson.RPCError{
 				Code:    btcjson.ErrRPCInvalidParameter,
 				Message: "With 0 protection level, HashOrData should represent 32 byte hash",

--- a/txscript/script.go
+++ b/txscript/script.go
@@ -484,10 +484,11 @@ func shallowCopyTx(tx *wire.MsgTx) wire.MsgTx {
 	// pointers into the contiguous arrays.  This avoids a lot of small
 	// allocations.
 	txCopy := wire.MsgTx{
-		Version:  tx.Version,
-		TxIn:     make([]*wire.TxIn, len(tx.TxIn)),
-		TxOut:    make([]*wire.TxOut, len(tx.TxOut)),
-		LockTime: tx.LockTime,
+		Version:       tx.Version,
+		TxIn:          make([]*wire.TxIn, len(tx.TxIn)),
+		TxOut:         make([]*wire.TxOut, len(tx.TxOut)),
+		LockTime:      tx.LockTime,
+		PosCommitment: tx.PosCommitment,
 	}
 	txIns := make([]wire.TxIn, len(tx.TxIn))
 	for i, oldTxIn := range tx.TxIn {

--- a/wire/msgtx.go
+++ b/wire/msgtx.go
@@ -446,6 +446,28 @@ func (c *Commitmment) SerializeSize() int {
 	return 73 + VarIntSerializeSize(uint64(len(c.PosSig))) + len(c.PosSig)
 }
 
+// Creates deep copy of the commitment
+func (c *Commitmment) Copy() *Commitmment {
+	newPosSig := make([]uint8, len(c.PosSig))
+	copy(newPosSig, c.PosSig[:])
+
+	newTag := [TagSize]uint8{}
+	copy(newTag[:], c.Tag[:])
+
+	newHash := [chainhash.HashSize]uint8{}
+	copy(newHash[:], c.HashCommitment[:])
+
+	commCopy := Commitmment{
+		Tag:            newTag,
+		verProt:        c.verProt,
+		DataSize:       c.DataSize,
+		HashCommitment: newHash,
+		Nonce:          c.Nonce,
+		PosSig:         newPosSig,
+	}
+	return &commCopy
+}
+
 func NewTxCommitment(
 	tag [TagSize]uint8,
 	version uint8,
@@ -603,6 +625,13 @@ func (msg *MsgTx) Copy() *MsgTx {
 		}
 		newTx.TxOut = append(newTx.TxOut, &newTxOut)
 	}
+
+	var commitment *Commitmment
+	if msg.PosCommitment != nil {
+		commitment = msg.PosCommitment.Copy()
+	}
+
+	newTx.PosCommitment = commitment
 
 	return &newTx
 }


### PR DESCRIPTION
Adds three basic integration tests:
- for  `createRawTransaction` endpoint
- `sendRawTransaction` endpoint and including transaction in mined block
- `sendRawTransaction` endpoint and including transaction in mined block, and propagating it too second node